### PR TITLE
Add blog post: The Urge to Not Care

### DIFF
--- a/src/content/posts.ts
+++ b/src/content/posts.ts
@@ -17,6 +17,15 @@ export type PostMeta = {
 };
 
 const META: Record<string, Omit<PostMeta, "slug">> = {
+  "the-urge-to-not-care": {
+    title: "The Urge to Not Care",
+    date: "10 Jul 2026",
+    iso: "2026-07-10",
+    excerpt:
+      "Somehow, knowingly or unknowingly, I have come to realise that I have sold my soul to the LLM. The war ensues.",
+    readingTime: "4 min",
+    location: "London",
+  },
   "why-i-decommissioned-aws": {
     title: "Why I Decommissioned AWS and Moved to Railway",
     date: "10 Jun 2026",

--- a/src/content/posts/the-urge-to-not-care.md
+++ b/src/content/posts/the-urge-to-not-care.md
@@ -1,0 +1,35 @@
+# The Urge to Not Care
+
+I have been battling with something lately. On one side, the augmented reality of the AI mindset. On the other, the slow erosion of my ability to retain information in my own brain cells. Somehow, knowingly or unknowingly, I have come to realise that I have sold my soul to the LLM.
+
+The war ensues.
+
+## The problem
+
+Let me give you some context on why I was, or still am, terrified of the wondrous progression of artificial intelligence.
+
+There was a time I felt proud of writing code by hand. Fast, efficient, effective. Remembering software engineering principles and patterns like a true north star. Writing clean, understandable code. Treating observability, scalability, reliability and availability as first class citizens. I wore them as a badge of honour and swore by them. The ability to hold domain knowledge in my head. Knowing how to wire a system end to end, not just figuratively but literally.
+
+Nowadays, all that hard graft feels like a distant memory.
+
+Here is what I mean. A few weeks ago I shipped a small browser game on this very site. Physics, enemy waves, collision detection, the lot. Fourteen years of software engineering and I barely typed a line of it. I described what I wanted, reviewed what came back, and nudged. It was live within days. And when it shipped, I felt efficient. Not proud. Efficient. There is a difference, and I only noticed it because of how loudly the pride used to arrive.
+
+Don't get me wrong. I am still passionate about the craft. Without those hard skills I couldn't call myself an AI prompt engineer, pun intended. You still need them. To review, to smell when something is off, to know what good looks like. But it is really different now, don't you think?
+
+Let me be honest with you. I don't miss the hours of debugging to find the source of a problem. I don't miss the tough coding peripherals. I don't miss the long endless nights curating scripts and writing complex services. But the synthetic challenges are not giving me the same joy I used to get from the tunnel vision manual art of software. That deep satisfaction which arrived once in a while, or often, before the era of AI.
+
+Does that make sense to you?
+
+## What now?
+
+The current state of play is talking to your LLM, coming up with a solid plan, reviewing it, and hammering it away. Well, getting your AI minions to hammer it away. And my struggles have changed shape entirely. I don't wrestle with the software epics themselves any more. I wrestle with context management, because an agent with a bloated context produces confident nonsense. I keep a cautious eye on security, because code I didn't write is code I didn't think about. I spend my evenings making sure the agents doing my work are robust enough to be trusted with it. It is babysitting, if I am honest. Management of a workforce that never sleeps and never gets tired of me.
+
+Of course there are still challenges. I am not an infra engineer, and the infrastructure setup, scale and robustness still trip me up. But I am sure AI will eventually make all of that foolproof too. It has already proved my doubts wrong once.
+
+So, back to what I asked earlier. Am I better or worse for using AI to drive into infinity and beyond?
+
+If you forced me to answer today, I would say better. I ship more, I learn faster, and I would not go back. But here is the honest part. I keep telling myself I should hold a few problems back. Keep a bug or two for myself, keep the muscle warm. I never do. The moment something gets hard, I hand it straight to the LLM. And that is the exact fear I am talking about. Nobody took the joy from me. I gave it away willingly, and I keep giving it away, every single day.
+
+Dare I urge to care, or is resistance futile?
+
+I could ask the LLM. But this is one problem I am keeping for myself.


### PR DESCRIPTION
## Summary
- New essay: "The Urge to Not Care" (10 Jul 2026, 4 min read) on trading the joy of hand-written code for AI-driven development
- Adds `src/content/posts/the-urge-to-not-care.md` and its META entry in `src/content/posts.ts`

## Verification
- `npm run build` passes with the new post included

🤖 Generated with [Claude Code](https://claude.com/claude-code)