### PR TITLE
Hire page: show only featured projects

### DIFF
--- a/src/routes/hire.tsx
+++ b/src/routes/hire.tsx
@@ -255,7 +255,7 @@ function HirePage() {
       <section className="relative z-10 mx-auto max-w-[1100px] px-6 pb-24">
         <SectionHeader index="03" label="Selected Projects" caption="Shipped & shelved" />
         <div className="mt-10 grid gap-6 sm:grid-cols-2">
-          {projects.map((p) => (
+          {projects.filter((p) => p.featured).map((p) => (
             <article
               key={p.title}
               className="group relative overflow-hidden rounded-2xl border border-foreground/10 bg-ink-soft/40 p-7 hover:border-ember/40 transition-colors"


### PR DESCRIPTION
## Summary
- The "Selected Projects" section on /hire was rendering all 10 projects, including legacy ones (Premier League Bot, Data Structures Visualizer, Twitter Mood Generator, Alexa Skills)
- Now filters to featured projects only: Softly, StaffOS, PulseCheck, Warden Zero, Make Nepal Great, Stock Intelligence

## Verification
- `npm run build` passes
- Checked /hire on local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)