### PR TITLE
Add StaffOS site link

### DIFF
--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -25,6 +25,7 @@ export const projects: Project[] = [
     description:
       "The trust, review, and documentation layer for AI-assisted engineering work.",
     tech: ["Ruby", "Rails", "PostgreSQL"],
+    demo: "https://staffos.rajgurung.me",
     github: "https://github.com/rajgurung/staffOS",
     image: "/images/projects/staffos.png",
     featured: true,


### PR DESCRIPTION
## Summary
- StaffOS project card now links to the live site at https://staffos.rajgurung.me (shows the "Live ↗" link on the homepage strip, projects page, and hire page)

## Verification
- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)