### PR TITLE
Update hire messaging: currently at Hexarad

### DIFF
--- a/src/components/site/Chrome.tsx
+++ b/src/components/site/Chrome.tsx
@@ -69,7 +69,7 @@ export function Nav({ theme, toggleTheme }: { theme: string; toggleTheme: () => 
           className="hidden sm:inline-flex items-center gap-2 rounded-full border border-ember/40 px-3.5 py-1.5 text-ember hover:bg-ember hover:text-ink transition-colors"
           activeProps={{ className: "bg-ember text-ink" }}
         >
-          Hire me
+          Work with me
           <span aria-hidden>→</span>
         </Link>
         <button

--- a/src/routes/hire.tsx
+++ b/src/routes/hire.tsx
@@ -7,17 +7,17 @@ import { Linkedin } from "lucide-react";
 export const Route = createFileRoute("/hire")({
   head: () => ({
     meta: [
-      { title: "Hire Raj Gurung — Senior Software Engineer & Technical Partner" },
+      { title: "Work with Raj Gurung — Senior Software Engineer & Technical Partner" },
       {
         name: "description",
         content:
-          "Available for hire. 15 years building systems at scale — distributed architectures, performance, observability, and AI-assisted dev workflows.",
+          "Currently at Hexarad. 15 years building systems at scale — distributed architectures, performance, observability, and AI-assisted dev workflows.",
       },
-      { property: "og:title", content: "Hire Raj Gurung — Senior / Staff Engineering" },
+      { property: "og:title", content: "Work with Raj Gurung — Senior / Staff Engineering" },
       {
         property: "og:description",
         content:
-          "Pragmatic architecture, production observability, and teams that own their systems end-to-end. Open to contract or full-time.",
+          "Pragmatic architecture, production observability, and teams that own their systems end-to-end. Always open to interesting conversations.",
       },
     ],
   }),

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -285,11 +285,12 @@ function HireBlock() {
               Currently
             </span>
             <h3 className="mt-3 font-display text-3xl sm:text-4xl font-medium tracking-tight text-balance">
-              Available for hire — Senior / Staff engineering.
+              Engineering at Hexarad — Senior / Staff.
             </h3>
             <p className="mt-4 text-foreground/60 leading-relaxed">
               Distributed systems, Rails platforms, observability rollouts,
-              and AI-assisted dev workflows. Open to contract or full-time.
+              and AI-assisted dev workflows. Always open to interesting
+              conversations.
             </p>
           </div>
           <div className="flex flex-col sm:items-end gap-3">
@@ -297,7 +298,7 @@ function HireBlock() {
               to="/hire"
               className="group inline-flex items-center gap-3 self-start rounded-full bg-ember px-7 py-3.5 font-display text-[12px] uppercase tracking-[0.25em] text-ink hover:bg-ember-glow transition-colors"
             >
-              Hire me
+              Work with me
               <span aria-hidden className="transition-transform group-hover:translate-x-1">
                 →
               </span>


### PR DESCRIPTION
## Summary
- Homepage hire block: "Available for hire" → "Engineering at Hexarad — Senior / Staff." with "Always open to interesting conversations"
- Nav and homepage CTA: "Hire me" → "Work with me"
- /hire meta tags updated to match (no more "Available for hire" / "Open to contract or full-time")
- /hire URL and page content unchanged (hero already said "Currently at Hexarad")

## Verification
- `npm run build` passes, no stale copy remains (grepped)
- Checked on local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)